### PR TITLE
FIX - incremental change should be signed integer

### DIFF
--- a/src/UNIT_8ENCODER.cpp
+++ b/src/UNIT_8ENCODER.cpp
@@ -60,11 +60,11 @@ void UNIT_8ENCODER::setEncoderValue(uint8_t index, int32_t value) {
     writeBytes(_addr, reg, data, 4);
 }
 
-uint32_t UNIT_8ENCODER::getIncrementValue(uint8_t index) {
+int32_t UNIT_8ENCODER::getIncrementValue(uint8_t index) {
     uint8_t data[4];
     uint8_t reg = index * 4 + INCREMENT_REG;
     readBytes(_addr, reg, data, 4);
-    uint32_t value =
+    int32_t value =
         data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24);
     return value;
 }

--- a/src/UNIT_8ENCODER.h
+++ b/src/UNIT_8ENCODER.h
@@ -29,7 +29,7 @@ class UNIT_8ENCODER {
                uint8_t sda = 21, uint8_t scl = 22, uint32_t speed = 100000L);
     uint32_t getEncoderValue(uint8_t index);
     void setEncoderValue(uint8_t index, int32_t value);
-    uint32_t getIncrementValue(uint8_t index);
+    int32_t getIncrementValue(uint8_t index);
     bool getButtonStatus(uint8_t index);
     bool getSwitchStatus(void);
     void setLEDColor(uint8_t index, uint32_t color);


### PR DESCRIPTION
The incremental change when turning the encoder left or right can be positive or negative and hence should be a signed integer.

Right now it returns positive values of about 1 or 2 when turned one way, and positive values of about 2147483648 when turned the other way. The embedded firmware on the encoder seems to be sending signed integers as the incremental change; this change to the M5Unit-8Encoder library aligns with that.