### PR TITLE
ENH - use signed integer as return value when getting the encoder value

### DIFF
--- a/src/UNIT_8ENCODER.cpp
+++ b/src/UNIT_8ENCODER.cpp
@@ -40,11 +40,11 @@ bool UNIT_8ENCODER::begin(TwoWire *wire, uint8_t addr, uint8_t sda, uint8_t scl,
     }
 }
 
-uint32_t UNIT_8ENCODER::getEncoderValue(uint8_t index) {
+int32_t UNIT_8ENCODER::getEncoderValue(uint8_t index) {
     uint8_t data[4];
     uint8_t reg = index * 4 + ENCODER_REG;
     readBytes(_addr, reg, data, 4);
-    uint32_t value =
+    int32_t value =
         data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24);
     return value;
 }

--- a/src/UNIT_8ENCODER.h
+++ b/src/UNIT_8ENCODER.h
@@ -27,7 +27,7 @@ class UNIT_8ENCODER {
    public:
     bool begin(TwoWire* wire = &Wire, uint8_t addr = ENCODER_ADDR,
                uint8_t sda = 21, uint8_t scl = 22, uint32_t speed = 100000L);
-    uint32_t getEncoderValue(uint8_t index);
+    int32_t getEncoderValue(uint8_t index);
     void setEncoderValue(uint8_t index, int32_t value);
     uint32_t getIncrementValue(uint8_t index);
     bool getButtonStatus(uint8_t index);


### PR DESCRIPTION
At the moment the value of the encoder is small positive numbers, or when turned the other way, numbers in the order of magnitude of 4294967295. This is due to the binary overflow of the uint32_t data type.

I noticed in the code that the `setEncoderValue` method is defined like this with a signed int32_t value
```
    void setEncoderValue(uint8_t index, int32_t value);
```

I believe it makes more sense if the `getEncoderValue` method also returns a signed int32_t value rather than an uint32_t , and changed the code accordingly. I consider this a harmless change: existing Arduino code from other 8Encoder owners that assigns the value returned by `getEncoderValue` to an uint32_t would remain working exactly the same as before.
