### PR TITLE
ENH - use consistent library name

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
-  "name": "M5UNIT_8Encoder",
-  "description": "Library for M5Stack Unit-8Encoder",
+  "name": "M5Unit-8Encoder",
+  "description": "Library for M5Stack M5Unit-8Encoder",
   "keywords": "M5Stack Unit-8Encoder",
   "authors": {
     "name": "M5Stack",

--- a/library.properties
+++ b/library.properties
@@ -1,8 +1,8 @@
-name=M5UNIT_8Encoder
+name=M5Unit-8Encoder
 version=0.0.1
 author=M5Stack
 maintainer=M5Stack
-sentence=Library for M5UNIT_8Encoder
+sentence=Library for M5Unit-8Encoder
 paragraph=See more on http://M5Stack.com
 category=Device Control
 url=https://github.com/m5stack/M5Unit-8Encoder


### PR DESCRIPTION
Changed capitalization and replaced underscore with dash. 

This makes the names of the library (as shown in the Arduino Library manager) consistent with that of nearly all other M5Unit-xxx libraries. Furthermore, it makes it consistent with the repository name on GitHub.

See also https://github.com/m5stack/M5Unit-8Angle/pull/2