### PR TITLE
ENH - make initialization with begin() consistent with M5Unit-8Angle

### DIFF
--- a/src/UNIT_8ENCODER.cpp
+++ b/src/UNIT_8ENCODER.cpp
@@ -40,6 +40,38 @@ bool UNIT_8ENCODER::begin(TwoWire *wire, uint8_t addr, uint8_t sda, uint8_t scl,
     }
 }
 
+bool UNIT_8ENCODER::begin(uint8_t addr, uint8_t sda, uint8_t scl,
+                          uint32_t speed) {
+    _wire  = &Wire;
+    _addr  = addr;
+    _sda   = sda;
+    _scl   = scl;
+    _speed = speed;
+    _wire->begin(sda, scl, speed);
+    delay(10);
+    _wire->beginTransmission(_addr);
+    uint8_t error = _wire->endTransmission();
+    if (error == 0) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool UNIT_8ENCODER::begin(uint8_t addr) {
+    _wire = &Wire;
+    _addr = addr;
+    _wire->begin();
+    delay(10);
+    _wire->beginTransmission(_addr);
+    uint8_t error = _wire->endTransmission();
+    if (error == 0) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 int32_t UNIT_8ENCODER::getEncoderValue(uint8_t index) {
     uint8_t data[4];
     uint8_t reg = index * 4 + ENCODER_REG;

--- a/src/UNIT_8ENCODER.h
+++ b/src/UNIT_8ENCODER.h
@@ -25,6 +25,9 @@ class UNIT_8ENCODER {
     void readBytes(uint8_t addr, uint8_t reg, uint8_t* buffer, uint8_t length);
 
    public:
+    bool begin(uint8_t addr = ENCODER_ADDR);
+    bool begin(uint8_t addr = ENCODER_ADDR, uint8_t sda = 21, 
+               uint8_t scl = 22, uint32_t speed = 100000L);
     bool begin(TwoWire* wire = &Wire, uint8_t addr = ENCODER_ADDR,
                uint8_t sda = 21, uint8_t scl = 22, uint32_t speed = 100000L);
     int32_t getEncoderValue(uint8_t index);

--- a/src/UNIT_8ENCODER.h
+++ b/src/UNIT_8ENCODER.h
@@ -26,8 +26,8 @@ class UNIT_8ENCODER {
 
    public:
     bool begin(uint8_t addr = ENCODER_ADDR);
-    bool begin(uint8_t addr = ENCODER_ADDR, uint8_t sda = 21, 
-               uint8_t scl = 22, uint32_t speed = 100000L);
+    bool begin(uint8_t addr = ENCODER_ADDR, uint8_t sda = 21, uint8_t scl = 22,
+               uint32_t speed = 100000L);
     bool begin(TwoWire* wire = &Wire, uint8_t addr = ENCODER_ADDR,
                uint8_t sda = 21, uint8_t scl = 22, uint32_t speed = 100000L);
     int32_t getEncoderValue(uint8_t index);


### PR DESCRIPTION
This adds an overloaded begin() method, allowing the user not to specify the SDA, SCL and speed manually, but rather rely on the defaults as for example specified in the M5Unified, M5Dial, or the M5NanoC6 libraries. Furthermore, it adds an overloaded begin() with the options, but without exposing the Wire object pointer.

See also https://github.com/m5stack/M5Unit-8Angle/pull/3. 

These two pull requests make the initialization of the 8Angle and the 8Encoder similar.  